### PR TITLE
fix(docker): use Node 14 base image to ensure compatibility with Vue CLI & legacy Webpack

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:lts AS builder
+FROM node:14 AS builder
 WORKDIR /app
 COPY package*.json /app/
 RUN npm ci


### PR DESCRIPTION
Old Docker build failed due to OpenSSL errors caused by newer Node.js versions
(Node 18+). Voorwiel uses Vue 2 + an older Webpack pipeline, which requires
Node.js 14 for stable builds.

This change updates the Dockerfile to use `node:14`, fixing the build process
and allowing the project to be built and served reliably.